### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-smoke.yml
+++ b/.github/workflows/security-smoke.yml
@@ -1,5 +1,8 @@
 name: Security Smoke Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/TangMan69/mcp-consulting-kit/security/code-scanning/5](https://github.com/TangMan69/mcp-consulting-kit/security/code-scanning/5)

In general, to fix this class of issue you explicitly specify the minimal required GITHUB_TOKEN permissions either at the workflow root (applies to all jobs) or per job. For this workflow, the jobs only need to read repository contents to check out code; they don’t need to write to the repo or manage issues/PRs. The best fix is therefore to add a `permissions:` block at the top level of `.github/workflows/security-smoke.yml` with `contents: read`, which constrains the token for all jobs without altering their behavior.

Concretely, in `.github/workflows/security-smoke.yml`, insert a `permissions:` section after the `name:` line (line 1) and before the `on:` section (line 3). The block should set `contents: read`. No additional imports or methods are needed because this is purely a YAML configuration change to the GitHub Actions workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
