### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-smoke.yml
+++ b/.github/workflows/security-smoke.yml
@@ -1,5 +1,8 @@
 name: Security Smoke Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/TangMan69/mcp-consulting-kit/security/code-scanning/6](https://github.com/TangMan69/mcp-consulting-kit/security/code-scanning/6)

In general, the fix is to add an explicit `permissions` block that grants the least privileges required for the workflow. Since these jobs only need to read the repository contents (for checkout and scanning) and do not write anything back to GitHub, `contents: read` is sufficient. Adding this at the workflow root will apply to both jobs.

The best minimal fix without altering behavior is to insert a top-level `permissions` block right after the workflow `name:` (before `on:`) in `.github/workflows/security-smoke.yml`:

```yaml
permissions:
  contents: read
```

This ensures `GITHUB_TOKEN` is restricted to read-only repository content for all jobs in this workflow. No imports or additional definitions are needed, and no job-level overrides are required unless later jobs need different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
