### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/showcase-servers/common/security.py
+++ b/showcase-servers/common/security.py
@@ -104,10 +104,12 @@ def _is_sensitive_key(key: str) -> bool:
 def _mask_secret(value: Any) -> str:
     text = str(value)
     if not text:
+        # Preserve empty/None semantics without introducing a marker
         return text
-    if len(text) <= 6:
-        return SENSITIVE_FIELD_MARKER
-    return f"{text[:2]}...{text[-2:]}"
+    # For any non-empty sensitive value, return a constant marker so that
+    # no part of the original secret (prefix, suffix, or exact length)
+    # is exposed in logs.
+    return SENSITIVE_FIELD_MARKER
 
 
 def redact_sensitive_data(value: Any, key_name: str | None = None) -> Any:


### PR DESCRIPTION
Potential fix for [https://github.com/TangMan69/mcp-consulting-kit/security/code-scanning/3](https://github.com/TangMan69/mcp-consulting-kit/security/code-scanning/3)

In general, to fix clear-text logging of sensitive information you must ensure that any potentially sensitive value is either (a) completely removed from logs or (b) replaced with a non-reversible placeholder that does not reveal the underlying data (no prefixes/suffixes, no full length, etc.). Masking that preserves parts of the secret is often still considered logging a secret in clear text for security tooling and compliance.

For this specific code, the best minimal fix is to strengthen `_mask_secret` so that it never includes any portion of the original secret in the logged string. Instead of returning a partially masked string like `ab...yz`, it should return a fixed marker such as `"***"` or `"*** REDACTED ***"`, potentially with very coarse length bucketing if needed, but without including any characters from the secret. This preserves existing functionality in the sense that sensitive values continue to be distinguishable from non-sensitive ones and remain non-empty placeholders, while eliminating any actual secret content from the log. The rest of the pipeline (`redact_sensitive_data`, `_build_log_payload`, and the final `logger.info(json.dumps(payload, ...))`) can remain unchanged because once `_mask_secret` returns a fully redacted marker, the payload no longer carries secret data.

Concretely, in `showcase-servers/common/security.py` you should modify the body of `_mask_secret` (around lines 104–110) to stop returning any part of the original string for any length. It can still handle empty values as before. No new imports are needed, and no other functions require changes because they already defer to `_mask_secret` for sensitive keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
