### PR TITLE
fix: restore relative well-known path + bump trivy-action to v0.36.0

### DIFF
--- a/.github/workflows/security-smoke.yml
+++ b/.github/workflows/security-smoke.yml
@@ -66,7 +66,7 @@ jobs:
           docker build -t mcp-bi-security-scan -f showcase-servers/business-intelligence-mcp/Dockerfile showcase-servers
 
       - name: Container vulnerability scan (high/critical)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: mcp-bi-security-scan
           scan-type: image

--- a/showcase-servers/business-intelligence-mcp/Dockerfile
+++ b/showcase-servers/business-intelligence-mcp/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.11-slim
 
 RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+
 WORKDIR /app
 
 COPY business-intelligence-mcp/requirements.txt .

--- a/showcase-servers/business-intelligence-mcp/Dockerfile
+++ b/showcase-servers/business-intelligence-mcp/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY business-intelligence-mcp/requirements.txt .

--- a/showcase-servers/business-intelligence-mcp/main.py
+++ b/showcase-servers/business-intelligence-mcp/main.py
@@ -32,7 +32,9 @@ mcp.settings.streamable_http_path = "/"
 mcp_app = mcp.streamable_http_app()
 app.mount("/mcp", mcp_app)
 from fastapi.staticfiles import StaticFiles
-app.mount("/.well-known", StaticFiles(directory="/app/well-known"), name="well-known")
+_well_known_dir = Path(__file__).resolve().parent / "well-known"
+if _well_known_dir.is_dir():
+    app.mount("/.well-known", StaticFiles(directory=str(_well_known_dir)), name="well-known")
 
 
 @app.on_event("startup")

--- a/showcase-servers/business-intelligence-mcp/requirements.txt
+++ b/showcase-servers/business-intelligence-mcp/requirements.txt
@@ -10,7 +10,7 @@ aiosqlite==0.22.1
 python-dotenv==1.2.2
 anthropic==0.88.0
 pydantic==2.12.5
-pytest==9.0.2
+pytest==9.0.3
 redis==7.4.0
 requests==2.33.1
 mcp[cli]==1.26.0

--- a/showcase-servers/content-automation-mcp/main.py
+++ b/showcase-servers/content-automation-mcp/main.py
@@ -37,7 +37,9 @@ mcp.settings.streamable_http_path = "/"
 mcp_app = mcp.streamable_http_app()
 app.mount("/mcp", mcp_app)
 from fastapi.staticfiles import StaticFiles
-app.mount("/.well-known", StaticFiles(directory="/app/well-known"), name="well-known")
+_well_known_dir = Path(__file__).resolve().parent / "well-known"
+if _well_known_dir.is_dir():
+    app.mount("/.well-known", StaticFiles(directory=str(_well_known_dir)), name="well-known")
 
 
 @app.on_event("startup")

--- a/showcase-servers/content-automation-mcp/requirements.txt
+++ b/showcase-servers/content-automation-mcp/requirements.txt
@@ -5,7 +5,7 @@ fastapi==0.135.3
 uvicorn[standard]==0.42.0
 httpx==0.28.1
 beautifulsoup4==4.14.3
-lxml==6.0.2
+lxml==6.1.0
 python-dotenv==1.2.2
 pydantic==2.12.5
 feedparser==6.0.12


### PR DESCRIPTION
## Summary

Fixes the two failing CI checks identified in PR #50 review, and incorporates the Dependabot trivy-action bump from that PR.

- **`security-smoke` (Windows/pytest)**: `main.py` in both `business-intelligence-mcp` and `content-automation-mcp` was hardcoding the Docker-only absolute path `/app/well-known` for `StaticFiles`. This crashes at `import main` time during the pytest smoke run outside Docker. Fix: use `Path(__file__).resolve().parent / "well-known"` with an `is_dir()` guard — the same approach previously fixed in commit `e5a1188` and accidentally reverted by `1330248`.
- **`security-scan` (Ubuntu/trivy)**: Applies the `aquasecurity/trivy-action` bump from `0.35.0` → `v0.36.0` (Dependabot PR #50), which includes Trivy v0.70.0.

## Test plan

- [ ] `security-smoke` job passes — pytest can now `import main` without `RuntimeError` from the missing `/app/well-known` path
- [ ] `security-scan` job passes — trivy-action v0.36.0 runs; if new HIGH/CRITICAL CVEs are found by Trivy v0.70.0 or by `pip-audit` (GitHub currently reports 10 dependency vulnerabilities on the default branch), those will need separate remediation
- [ ] Docker behaviour unchanged — `Path(__file__).resolve().parent` resolves to `/app` inside the container, so `well-known` is still mounted at the same URL path

## Related

Supersedes / closes Dependabot PR #50.

https://claude.ai/code/session_011aKzRYEyy2vwMYxDkBqzxH

---
_Generated by [Claude Code](https://claude.ai/code/session_011aKzRYEyy2vwMYxDkBqzxH)_