### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/showcase-servers/content-automation-mcp/security.py
+++ b/showcase-servers/content-automation-mcp/security.py
@@ -148,7 +148,8 @@ def _build_log_payload(
 ) -> dict:
     client_ip = request.client.host if request.client else "unknown"
     user_agent = request.headers.get("user-agent", "")
-    redacted_headers = redact_sensitive_data(dict(request.headers))
+    content_type = request.headers.get("content-type", "")
+    content_length = request.headers.get("content-length", "")
     return {
         "event": "http_request",
         "service": service_name,
@@ -159,7 +160,11 @@ def _build_log_payload(
         "duration_ms": round(duration_ms, 2),
         "client_ip": client_ip,
         "user_agent": user_agent,
-        "headers": redacted_headers,
+        "header_summary": {
+            "user_agent_present": bool(user_agent),
+            "content_type": content_type,
+            "content_length": content_length,
+        },
     }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/JRM-FusionAL/mcp-consulting-kit/security/code-scanning/8](https://github.com/JRM-FusionAL/mcp-consulting-kit/security/code-scanning/8)

General fix: avoid logging potentially sensitive material altogether, rather than relying on masking heuristics. Replace broad header logging with an explicit safe subset (or remove it entirely).

Best minimal fix in `showcase-servers/content-automation-mcp/security.py`:
- In `_build_log_payload(...)`, remove creation/use of `redacted_headers`.
- Replace `"headers": redacted_headers` with a new `"header_summary"` object containing only non-sensitive observability fields (for example `user_agent_present`, `content_type`, `content_length`), using direct header lookups.
- Keep existing behavior for request logging otherwise unchanged (event name, request id, method/path/status/duration, client IP, user agent).

This addresses both alert variants at the same sink (`json.dumps(payload, ...)`) by ensuring sensitive header values are no longer included in the serialized payload.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
