### PR TITLE
Potential fix for code scanning alert no. 13: Clear-text logging of sensitive information

### DIFF
--- a/showcase-servers/business-intelligence-mcp/showcase_servers/common/security.py
+++ b/showcase-servers/business-intelligence-mcp/showcase_servers/common/security.py
@@ -157,7 +157,6 @@ def _build_log_payload(
 ) -> dict:
     client_ip = request.client.host if request.client else "unknown"
     user_agent = request.headers.get("user-agent", "")
-    redacted_headers = redact_sensitive_data(dict(request.headers))
     payload = {
         "event": "http_request",
         "service": service_name,
@@ -168,7 +167,6 @@ def _build_log_payload(
         "duration_ms": round(duration_ms, 2),
         "client_ip": client_ip,
         "user_agent": user_agent,
-        "headers": redacted_headers,
     }
     payload.update(_get_trace_context())
     return payload


### PR DESCRIPTION
Potential fix for [https://github.com/JRM-FusionAL/mcp-consulting-kit/security/code-scanning/13](https://github.com/JRM-FusionAL/mcp-consulting-kit/security/code-scanning/13)

General fix: ensure log payloads do not contain user-provided sensitive structures (especially headers), even if redacted. Prefer logging minimal, non-sensitive metadata.

Best fix in this file: in `_build_log_payload`, stop adding `headers` to the logged payload. Keep other existing fields unchanged. This preserves request logging behavior while removing the tainted path CodeQL reports (`redacted_headers -> payload -> json.dumps -> logger.info`).

File/region to change:
- `showcase-servers/business-intelligence-mcp/showcase_servers/common/security.py`
- In `_build_log_payload` around lines 160–172:
  - Remove `redacted_headers = redact_sensitive_data(dict(request.headers))`
  - Remove `"headers": redacted_headers,` from `payload`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
