### PR TITLE
Potential fix for code scanning alert no. 12: Clear-text logging of sensitive information

### DIFF
--- a/showcase-servers/content-automation-mcp/showcase_servers/common/security.py
+++ b/showcase-servers/content-automation-mcp/showcase_servers/common/security.py
@@ -157,7 +157,7 @@ def _build_log_payload(
 ) -> dict:
     client_ip = request.client.host if request.client else "unknown"
     user_agent = request.headers.get("user-agent", "")
-    redacted_headers = redact_sensitive_data(dict(request.headers))
+    header_names = sorted(dict(request.headers).keys())
     payload = {
         "event": "http_request",
         "service": service_name,
@@ -168,7 +168,8 @@ def _build_log_payload(
         "duration_ms": round(duration_ms, 2),
         "client_ip": client_ip,
         "user_agent": user_agent,
-        "headers": redacted_headers,
+        "header_names": header_names,
+        "header_count": len(header_names),
     }
     payload.update(_get_trace_context())
     return payload


### PR DESCRIPTION
Potential fix for [https://github.com/JRM-FusionAL/mcp-consulting-kit/security/code-scanning/12](https://github.com/JRM-FusionAL/mcp-consulting-kit/security/code-scanning/12)

Best practice is to **minimize logged sensitive surface**, not just redact values. Here, replace logged header values with a safe representation that preserves observability without exposing secrets.

Single best fix in `showcase-servers/content-automation-mcp/showcase_servers/common/security.py`:
- In `_build_log_payload`, stop including `redacted_headers` (header key/value map) in the payload.
- Instead include:
  - `header_names`: sorted list of header names (lower-risk metadata), and/or
  - `header_count`: number of headers.
- Keep all other behavior unchanged (request id, method, path, status, duration, trace context, etc.).

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
