### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/showcase-servers/business-intelligence-mcp/security.py
+++ b/showcase-servers/business-intelligence-mcp/security.py
@@ -148,7 +148,6 @@ def _build_log_payload(
 ) -> dict:
     client_ip = request.client.host if request.client else "unknown"
     user_agent = request.headers.get("user-agent", "")
-    redacted_headers = redact_sensitive_data(dict(request.headers))
     return {
         "event": "http_request",
         "service": service_name,
@@ -159,7 +158,6 @@ def _build_log_payload(
         "duration_ms": round(duration_ms, 2),
         "client_ip": client_ip,
         "user_agent": user_agent,
-        "headers": redacted_headers,
     }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/JRM-FusionAL/mcp-consulting-kit/security/code-scanning/9](https://github.com/JRM-FusionAL/mcp-consulting-kit/security/code-scanning/9)

General fix: do not log sensitive/untrusted fields that commonly carry secrets (especially full request headers). Prefer minimal metadata logging.

Best single fix here without changing core functionality: in `showcase-servers/business-intelligence-mcp/security.py`, update `_build_log_payload` so it no longer includes full `headers` in the emitted payload. Keep existing request observability fields (`method`, `path`, `status_code`, duration, etc.) intact. This directly removes the secret data-flow path that CodeQL reports and should address both variants at the same sink.

Concretely:
- In `_build_log_payload`, remove construction/use of `redacted_headers`.
- Remove `"headers": redacted_headers` from returned dict.
- No new imports/dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
