### PR TITLE
chore: bump Python dependencies (safe minor/patch)

### DIFF
--- a/showcase-servers/api-integration-hub/requirements.txt
+++ b/showcase-servers/api-integration-hub/requirements.txt
@@ -1,11 +1,11 @@
 # API Integration Hub
 # Updated: 2026-04-02
 
-fastapi==0.135.3
-uvicorn[standard]==0.42.0
+fastapi==0.138.1
+uvicorn[standard]==0.49.0
 httpx==0.28.1
 python-dotenv==1.2.2
-pydantic==2.12.5
+pydantic==2.13.4
 redis==7.4.0
-requests==2.33.1
-mcp[cli]==1.26.0
+requests==2.34.2
+mcp[cli]==1.28.1

--- a/showcase-servers/business-intelligence-mcp/requirements.txt
+++ b/showcase-servers/business-intelligence-mcp/requirements.txt
@@ -1,18 +1,18 @@
 # Business Intelligence MCP
 # Updated: 2026-04-02
 
-fastapi==0.135.3
-uvicorn[standard]==0.42.0
-sqlalchemy==2.0.48
+fastapi==0.138.1
+uvicorn[standard]==0.49.0
+sqlalchemy==2.0.51
 psycopg2-binary==2.9.11
 pymysql==1.1.2
 aiosqlite==0.22.1
 python-dotenv==1.2.2
-anthropic==0.88.0
+anthropic==0.112.0
 openai>=1.30.0
-pydantic==2.12.5
+pydantic==2.13.4
 pytest==9.0.3
 redis==7.4.0
-requests==2.33.1
-mcp[cli]==1.26.0
+requests==2.34.2
+mcp[cli]==1.28.1
 httpx==0.28.1

--- a/showcase-servers/content-automation-mcp/requirements.txt
+++ b/showcase-servers/content-automation-mcp/requirements.txt
@@ -1,14 +1,14 @@
 # Content Automation MCP
 # Updated: 2026-04-02
 
-fastapi==0.135.3
-uvicorn[standard]==0.42.0
+fastapi==0.138.1
+uvicorn[standard]==0.49.0
 httpx==0.28.1
-beautifulsoup4==4.14.3
-lxml==6.1.0
+beautifulsoup4==4.15.0
+lxml==6.1.1
 python-dotenv==1.2.2
-pydantic==2.12.5
+pydantic==2.13.4
 feedparser==6.0.12
 redis==7.4.0
-requests==2.33.1
-mcp[cli]==1.26.0
+requests==2.34.2
+mcp[cli]==1.28.1

--- a/showcase-servers/github-mcp-safe/requirements.txt
+++ b/showcase-servers/github-mcp-safe/requirements.txt
@@ -1,8 +1,8 @@
-fastapi==0.135.3
-uvicorn[standard]==0.42.0
-pydantic==2.12.5
+fastapi==0.138.1
+uvicorn[standard]==0.49.0
+pydantic==2.13.4
 httpx==0.28.1
-mcp[cli]==1.26.0
+mcp[cli]==1.28.1
 python-dotenv==1.2.2
 opentelemetry-sdk==1.40.0
 opentelemetry-instrumentation-fastapi==0.61b0

--- a/showcase-servers/social-poster-mcp/requirements.txt
+++ b/showcase-servers/social-poster-mcp/requirements.txt
@@ -1,12 +1,12 @@
 # Social Poster MCP
 # Updated: 2026-03-12
 
-fastapi==0.135.1
-uvicorn[standard]==0.41.0
+fastapi==0.138.1
+uvicorn[standard]==0.49.0
 httpx==0.28.1
 python-dotenv==1.2.2
-pydantic==2.12.5
-redis==7.3.0
-requests==2.33.0
-mcp[cli]==1.26.0
+pydantic==2.13.4
+redis==7.4.0
+requests==2.34.2
+mcp[cli]==1.28.1
 requests-oauthlib==2.0.0


### PR DESCRIPTION
## Python Dependency Bumps — 2026-06-27

### Safe bumps applied (5 servers)
| Package | From | To |
|---------|------|----|
| fastapi | 0.135.x | 0.138.1 |
| uvicorn | 0.41/0.42 | 0.49.0 |
| pydantic | 2.12.5 | 2.13.4 |
| mcp[cli] | 1.26.0 | 1.28.1 |
| requests | 2.33.x | 2.34.2 |
| anthropic | 0.88.0 | 0.112.0 |
| sqlalchemy | 2.0.48 | 2.0.51 |
| beautifulsoup4 | 4.14.3 | 4.15.0 |
| lxml | 6.1.0 | 6.1.1 |
| tweepy | 4.15.0 | 4.16.0 |
| redis | 7.2/7.3 | 7.4.0 (normalized) |

### Intentionally skipped (major breaking)
- **redis 7→8**: Major API changes, needs manual migration
- **praw 7→8**: Complete rewrite, needs code changes

### Node.js
- **@vitejs/plugin-react** 5.2.0→6.0.3 (major, breaking) — skipped
- **react/react-dom** 18→19 (major, breaking) — skipped

Both Node major bumps require code changes and should be done in dedicated PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What**  
Bumped safe minor/patch Python dependencies across multiple showcase servers to keep the MCP/FastAPI stacks current without introducing major-version migration work.

**Changes**  
- `showcase-servers/api-integration-hub/requirements.txt` — upgraded `fastapi`, `uvicorn[standard]`, `pydantic`, `requests`, and `mcp[cli]`.
- `showcase-servers/business-intelligence-mcp/requirements.txt` — upgraded core app deps including `fastapi`, `uvicorn[standard]`, `sqlalchemy`, `anthropic`, `pydantic`, `requests`, and `mcp[cli]`.
- `showcase-servers/content-automation-mcp/requirements.txt` — upgraded `fastapi`, `uvicorn[standard]`, `beautifulsoup4`, `lxml`, `pydantic`, `requests`, and `mcp[cli]`.
- `showcase-servers/github-mcp-safe/requirements.txt` — upgraded the FastAPI stack deps (`fastapi`, `uvicorn[standard]`, `pydantic`, `mcp[cli]`).
- `showcase-servers/social-poster-mcp/requirements.txt` — upgraded `fastapi`, `uvicorn[standard]`, `pydantic`, `redis`, `requests`, and `mcp[cli]`.

**Dependencies**  
- No new packages, env vars, or config were added.
- `redis` is normalized to `7.4.0` where updated.
- Major bumps were intentionally skipped for `redis`, `praw`, `@vitejs/plugin-react`, `react`, and `react-dom`.

**Testing**  
- Regenerate/install dependencies for each affected server and confirm lockfile/resolution succeeds.
- Start each showcase server and verify the app boots cleanly with the upgraded pins.
- Run existing smoke tests or API checks for the updated services.

**Contributors**

| Author | Lines added | Lines removed |
|---|---:|---:|
| Unknown | 29 | 29 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->