### PR TITLE
docs: update maintenance summary for 2026-06-27

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -69,4 +69,47 @@
 
 ### CI Status
 - PR #68: pending (Analyze, CodeRabbit, security-scan, security-smoke)
-- PR #69: pending (Analyze, CodeRabbit, security-scan, security-smoke)
+
+---
+
+## Maintenance Summary - 2026-06-27
+
+### Actions Taken
+- Merged 3 prior PRs (#68, #69, #70) — all CI green, CLEAN merge state
+- Bumped Python dependencies across 5 tracked showcase servers (PR #71)
+- Checked Node.js deps — only major version bumps remain (@vitejs/plugin-react 5→6, react 18→19), deferred
+- No open issues to triage
+- social-distribution-mcp/ is gitignored and untracked — requirements.txt changes not comittable
+
+### PRs Merged This Run
+- PR #68: chore: update Node.js dependencies in app ✅
+- PR #69: chore: update Node.js dependencies in frontend ✅
+- PR #70: docs: update maintenance summary for 2026-06-26 ✅
+
+### PRs Opened This Run
+- PR #71: chore: bump Python dependencies (safe minor/patch)
+
+### Dependency Audit Results
+
+**Python safe bumps applied (PR #71):**
+- fastapi: 0.135.x → 0.138.1
+- uvicorn: 0.41/0.42 → 0.49.0
+- pydantic: 2.12.5 → 2.13.4
+- mcp[cli]: 1.26.0 → 1.28.1
+- requests: 2.33.x → 2.34.2
+- anthropic: 0.88.0 → 0.112.0
+- sqlalchemy: 2.0.48 → 2.0.51
+- beautifulsoup4: 4.14.3 → 4.15.0
+- lxml: 6.1.0 → 6.1.1
+- tweepy: 4.15.0 → 4.16.0
+- redis: 7.2/7.3 → 7.4.0 (normalized)
+
+**Python intentionally skipped (major breaking):**
+- redis 7→8, praw 7→8 — require code migration
+
+**Node.js deferred (major breaking):**
+- @vitejs/plugin-react: 5.2.0 → 6.0.3
+- react/react-dom: 18.3.1 → 19.2.7
+
+### Issues Labeled
+- No unlabeled open issues found


### PR DESCRIPTION
Weekly maintenance summary update. Merged 3 prior PRs, opened Python deps bump PR #71, no issues to triage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What**  
Update the maintenance summary documentation for 2026-06-27.

**Changes**  
- `MAINTENANCE.md` — refreshed the CI status entry and replaced the pending PR reference from `#69` to `#68`.
- `MAINTENANCE.md` — added a new **Maintenance Summary - 2026-06-27** section covering merged PRs `#68`, `#69`, and `#70`, the opening of Python dependency bump PR `#71`, deferred Node.js dependency upgrades, and the current issue-triage status.

**Dependencies**  
- No new packages, env vars, or config were added.

**Testing**  
- Verify `MAINTENANCE.md` contains the updated CI reference and the new 2026-06-27 maintenance summary section.
- Confirm the documented PR statuses match the recorded merge/open/triage outcomes.

**Contributors**  

| Author | Lines added | Lines removed |
|---|---:|---:|
| Unknown | 44 | 1 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->