### PR TITLE
Potential fix for code scanning alert no. 11: Clear-text logging of sensitive information

### DIFF
--- a/showcase-servers/api-integration-hub/showcase_servers/common/security.py
+++ b/showcase-servers/api-integration-hub/showcase_servers/common/security.py
@@ -155,6 +155,19 @@ def _build_log_payload(
     duration_ms: float,
     service_name: str,
 ) -> dict:
+    """
+    Builds the structured payload for an HTTP request log entry.
+    
+    Parameters:
+    	request (Request): The incoming request.
+    	request_id (str): The request identifier to include in the payload.
+    	status_code (int): The response status code.
+    	duration_ms (float): The request duration in milliseconds.
+    	service_name (str): The service name to include in the payload.
+    
+    Returns:
+    	dict: A log payload containing request details, header names, and trace context.
+    """
     client_ip = request.client.host if request.client else "unknown"
     user_agent = request.headers.get("user-agent", "")
     header_names = sorted(dict(request.headers).keys())

--- a/showcase-servers/api-integration-hub/showcase_servers/common/security.py
+++ b/showcase-servers/api-integration-hub/showcase_servers/common/security.py
@@ -157,7 +157,7 @@ def _build_log_payload(
 ) -> dict:
     client_ip = request.client.host if request.client else "unknown"
     user_agent = request.headers.get("user-agent", "")
-    redacted_headers = redact_sensitive_data(dict(request.headers))
+    header_names = sorted(dict(request.headers).keys())
     payload = {
         "event": "http_request",
         "service": service_name,
@@ -168,7 +168,7 @@ def _build_log_payload(
         "duration_ms": round(duration_ms, 2),
         "client_ip": client_ip,
         "user_agent": user_agent,
-        "headers": redacted_headers,
+        "header_names": header_names,
     }
     payload.update(_get_trace_context())
     return payload

--- a/showcase-servers/api-integration-hub/showcase_servers/common/test_security_common.py
+++ b/showcase-servers/api-integration-hub/showcase_servers/common/test_security_common.py
@@ -370,3 +370,149 @@ def test_observability_logs_health_when_enabled(monkeypatch, caplog):
     assert response.status_code == 200
     payload = json.loads(caplog.records[-1].message)
     assert payload["path"] == "/health"
+
+
+def test_build_log_payload_header_names_is_sorted(monkeypatch, caplog):
+    """header_names must be sorted alphabetically (new behavior)."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="Sort Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get(
+            "/ping",
+            headers={
+                "Z-Custom": "z-value",
+                "A-Custom": "a-value",
+                "M-Custom": "m-value",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = json.loads(caplog.records[-1].message)
+    header_names = payload["header_names"]
+    assert header_names == sorted(header_names)
+
+
+def test_build_log_payload_header_names_is_list(monkeypatch, caplog):
+    """header_names must be a list, not a dict."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="Type Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get("/ping", headers={"Authorization": "Bearer token123"})
+
+    assert response.status_code == 200
+    payload = json.loads(caplog.records[-1].message)
+    assert isinstance(payload["header_names"], list)
+
+
+def test_build_log_payload_does_not_log_header_values(monkeypatch, caplog):
+    """Sensitive header values must not appear anywhere in the log payload."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="No Value Leak Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+    secret_token = "super-secret-bearer-xyz"
+
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get(
+            "/ping",
+            headers={"Authorization": f"Bearer {secret_token}"},
+        )
+
+    assert response.status_code == 200
+    log_message = caplog.records[-1].message
+    assert secret_token not in log_message
+
+
+def test_build_log_payload_no_headers_key_in_payload(monkeypatch, caplog):
+    """Regression: old 'headers' key must be absent from the log payload."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="Regression Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get("/ping", headers={"X-API-Key": "my-secret-key"})
+
+    assert response.status_code == 200
+    payload = json.loads(caplog.records[-1].message)
+    assert "headers" not in payload
+    assert "header_names" in payload
+
+
+def test_build_log_payload_header_names_present_with_no_custom_headers(monkeypatch, caplog):
+    """header_names is a non-empty list even when no custom headers are sent."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="Minimal Headers Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get("/ping")
+
+    assert response.status_code == 200
+    payload = json.loads(caplog.records[-1].message)
+    assert "header_names" in payload
+    # TestClient always sends at least host header
+    assert isinstance(payload["header_names"], list)
+    assert len(payload["header_names"]) >= 1
+
+
+def test_build_log_payload_api_key_value_not_logged(monkeypatch, caplog):
+    """Regression: X-API-Key value must not appear in header_names entries."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="API Key Value Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+    api_key_value = "my-api-key-value"
+
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get("/ping", headers={"X-API-Key": api_key_value})
+
+    assert response.status_code == 200
+    payload = json.loads(caplog.records[-1].message)
+    # The value must not appear anywhere in the logged header names
+    assert api_key_value not in payload["header_names"]
+    # The header name itself (lowercased) should be present
+    assert "x-api-key" in payload["header_names"]

--- a/showcase-servers/api-integration-hub/showcase_servers/common/test_security_common.py
+++ b/showcase-servers/api-integration-hub/showcase_servers/common/test_security_common.py
@@ -242,8 +242,8 @@ def test_observability_redacts_sensitive_headers(monkeypatch, caplog):
 
     assert response.status_code == 200
     payload = json.loads(caplog.records[-1].message)
-    assert payload["headers"]["authorization"] != "Bearer super-secret-token"
-    assert payload["headers"]["x-api-key"] != "my-api-key-value"
+    assert "authorization" in payload["header_names"]
+    assert "x-api-key" in payload["header_names"]
 
 
 def test_sanitize_request_id_accepts_valid_format():

--- a/showcase-servers/api-integration-hub/showcase_servers/common/test_security_common.py
+++ b/showcase-servers/api-integration-hub/showcase_servers/common/test_security_common.py
@@ -372,11 +372,11 @@ def test_observability_logs_health_when_enabled(monkeypatch, caplog):
     assert payload["path"] == "/health"
 
 
-def test_build_log_payload_header_names_is_sorted(monkeypatch, caplog):
-    """header_names must be sorted alphabetically (new behavior)."""
+def test_log_payload_header_names_is_a_list(monkeypatch, caplog):
+    """header_names in the log payload must be a list, not a dict."""
     monkeypatch.setenv("LOG_LEVEL", "INFO")
 
-    app = FastAPI(title="Sort Test")
+    app = FastAPI(title="HeaderList Test")
     security.configure_observability(app)
 
     @app.get("/ping")
@@ -384,14 +384,33 @@ def test_build_log_payload_header_names_is_sorted(monkeypatch, caplog):
         return {"ok": True}
 
     client = TestClient(app)
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get("/ping", headers={"X-Custom-Header": "some-value"})
 
+    assert response.status_code == 200
+    payload = json.loads(caplog.records[-1].message)
+    assert isinstance(payload["header_names"], list)
+
+
+def test_log_payload_header_names_sorted_alphabetically(monkeypatch, caplog):
+    """header_names must be sorted alphabetically."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="Sorted Headers Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
     with caplog.at_level("INFO", logger=security.LOGGER_NAME):
         response = client.get(
             "/ping",
             headers={
-                "Z-Custom": "z-value",
-                "A-Custom": "a-value",
-                "M-Custom": "m-value",
+                "Z-Last-Header": "z-value",
+                "A-First-Header": "a-value",
+                "M-Middle-Header": "m-value",
             },
         )
 
@@ -401,11 +420,11 @@ def test_build_log_payload_header_names_is_sorted(monkeypatch, caplog):
     assert header_names == sorted(header_names)
 
 
-def test_build_log_payload_header_names_is_list(monkeypatch, caplog):
-    """header_names must be a list, not a dict."""
+def test_log_payload_no_header_values_in_payload(monkeypatch, caplog):
+    """Header values must not appear anywhere in the log payload."""
     monkeypatch.setenv("LOG_LEVEL", "INFO")
 
-    app = FastAPI(title="Type Test")
+    app = FastAPI(title="No Values Test")
     security.configure_observability(app)
 
     @app.get("/ping")
@@ -413,45 +432,29 @@ def test_build_log_payload_header_names_is_list(monkeypatch, caplog):
         return {"ok": True}
 
     client = TestClient(app)
-
-    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
-        response = client.get("/ping", headers={"Authorization": "Bearer token123"})
-
-    assert response.status_code == 200
-    payload = json.loads(caplog.records[-1].message)
-    assert isinstance(payload["header_names"], list)
-
-
-def test_build_log_payload_does_not_log_header_values(monkeypatch, caplog):
-    """Sensitive header values must not appear anywhere in the log payload."""
-    monkeypatch.setenv("LOG_LEVEL", "INFO")
-
-    app = FastAPI(title="No Value Leak Test")
-    security.configure_observability(app)
-
-    @app.get("/ping")
-    def ping():
-        return {"ok": True}
-
-    client = TestClient(app)
-    secret_token = "super-secret-bearer-xyz"
+    secret_value = "Bearer super-secret-token-12345"
+    api_key_value = "my-very-secret-api-key"
 
     with caplog.at_level("INFO", logger=security.LOGGER_NAME):
         response = client.get(
             "/ping",
-            headers={"Authorization": f"Bearer {secret_token}"},
+            headers={
+                "Authorization": secret_value,
+                "X-API-Key": api_key_value,
+            },
         )
 
     assert response.status_code == 200
-    log_message = caplog.records[-1].message
-    assert secret_token not in log_message
+    raw_log = caplog.records[-1].message
+    assert secret_value not in raw_log
+    assert api_key_value not in raw_log
 
 
-def test_build_log_payload_no_headers_key_in_payload(monkeypatch, caplog):
-    """Regression: old 'headers' key must be absent from the log payload."""
+def test_log_payload_no_headers_key(monkeypatch, caplog):
+    """The old 'headers' key must not be present in the log payload."""
     monkeypatch.setenv("LOG_LEVEL", "INFO")
 
-    app = FastAPI(title="Regression Test")
+    app = FastAPI(title="No Headers Key Test")
     security.configure_observability(app)
 
     @app.get("/ping")
@@ -459,9 +462,8 @@ def test_build_log_payload_no_headers_key_in_payload(monkeypatch, caplog):
         return {"ok": True}
 
     client = TestClient(app)
-
     with caplog.at_level("INFO", logger=security.LOGGER_NAME):
-        response = client.get("/ping", headers={"X-API-Key": "my-secret-key"})
+        response = client.get("/ping", headers={"Authorization": "Bearer token"})
 
     assert response.status_code == 200
     payload = json.loads(caplog.records[-1].message)
@@ -469,11 +471,11 @@ def test_build_log_payload_no_headers_key_in_payload(monkeypatch, caplog):
     assert "header_names" in payload
 
 
-def test_build_log_payload_header_names_present_with_no_custom_headers(monkeypatch, caplog):
-    """header_names is a non-empty list even when no custom headers are sent."""
+def test_log_payload_header_names_contains_sent_names(monkeypatch, caplog):
+    """Non-sensitive header names must appear in header_names."""
     monkeypatch.setenv("LOG_LEVEL", "INFO")
 
-    app = FastAPI(title="Minimal Headers Test")
+    app = FastAPI(title="Header Names Present")
     security.configure_observability(app)
 
     @app.get("/ping")
@@ -481,38 +483,77 @@ def test_build_log_payload_header_names_present_with_no_custom_headers(monkeypat
         return {"ok": True}
 
     client = TestClient(app)
-
     with caplog.at_level("INFO", logger=security.LOGGER_NAME):
-        response = client.get("/ping")
+        response = client.get(
+            "/ping",
+            headers={
+                "X-Custom-Header": "value1",
+                "Accept-Language": "en-US",
+            },
+        )
 
     assert response.status_code == 200
     payload = json.loads(caplog.records[-1].message)
-    assert "header_names" in payload
-    # TestClient always sends at least host header
-    assert isinstance(payload["header_names"], list)
-    assert len(payload["header_names"]) >= 1
+    assert "x-custom-header" in payload["header_names"]
+    assert "accept-language" in payload["header_names"]
 
 
-def test_build_log_payload_api_key_value_not_logged(monkeypatch, caplog):
-    """Regression: X-API-Key value must not appear in header_names entries."""
-    monkeypatch.setenv("LOG_LEVEL", "INFO")
+def test_build_log_payload_header_names_directly():
+    """Unit test for _build_log_payload: header_names is sorted keys of request headers."""
+    headers = {"z-header": "z-val", "a-header": "a-val", "m-header": "m-val"}
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="10.0.0.1"),
+        headers=headers,
+        method="GET",
+        url=SimpleNamespace(path="/test"),
+    )
+    payload = security._build_log_payload(
+        request=request,
+        request_id="test-id",
+        status_code=200,
+        duration_ms=12.5,
+        service_name="test-service",
+    )
+    assert payload["header_names"] == ["a-header", "m-header", "z-header"]
+    assert "headers" not in payload
 
-    app = FastAPI(title="API Key Value Test")
-    security.configure_observability(app)
 
-    @app.get("/ping")
-    def ping():
-        return {"ok": True}
-
-    client = TestClient(app)
-    api_key_value = "my-api-key-value"
-
-    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
-        response = client.get("/ping", headers={"X-API-Key": api_key_value})
-
-    assert response.status_code == 200
-    payload = json.loads(caplog.records[-1].message)
-    # The value must not appear anywhere in the logged header names
-    assert api_key_value not in payload["header_names"]
-    # The header name itself (lowercased) should be present
+def test_build_log_payload_header_values_absent():
+    """Unit test: header values must not appear in _build_log_payload output."""
+    headers = {"authorization": "Bearer secret-token", "x-api-key": "sensitive-key"}
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="10.0.0.1"),
+        headers=headers,
+        method="POST",
+        url=SimpleNamespace(path="/data"),
+    )
+    payload = security._build_log_payload(
+        request=request,
+        request_id="req-abc",
+        status_code=201,
+        duration_ms=5.0,
+        service_name="svc",
+    )
+    serialized = json.dumps(payload)
+    assert "Bearer secret-token" not in serialized
+    assert "sensitive-key" not in serialized
+    assert "authorization" in payload["header_names"]
     assert "x-api-key" in payload["header_names"]
+
+
+def test_build_log_payload_empty_headers():
+    """Unit test: _build_log_payload with no request headers yields empty list."""
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="127.0.0.1"),
+        headers={},
+        method="GET",
+        url=SimpleNamespace(path="/empty"),
+    )
+    payload = security._build_log_payload(
+        request=request,
+        request_id="req-empty",
+        status_code=200,
+        duration_ms=1.0,
+        service_name="svc",
+    )
+    assert payload["header_names"] == []

--- a/showcase-servers/content-automation-mcp/showcase_servers/common/test_security_common.py
+++ b/showcase-servers/content-automation-mcp/showcase_servers/common/test_security_common.py
@@ -370,3 +370,149 @@ def test_observability_logs_health_when_enabled(monkeypatch, caplog):
     assert response.status_code == 200
     payload = json.loads(caplog.records[-1].message)
     assert payload["path"] == "/health"
+
+
+def test_build_log_payload_header_names_is_sorted(monkeypatch, caplog):
+    """header_names must be sorted alphabetically (new behavior)."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="Sort Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get(
+            "/ping",
+            headers={
+                "Z-Custom": "z-value",
+                "A-Custom": "a-value",
+                "M-Custom": "m-value",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = json.loads(caplog.records[-1].message)
+    header_names = payload["header_names"]
+    assert header_names == sorted(header_names)
+
+
+def test_build_log_payload_header_names_is_list(monkeypatch, caplog):
+    """header_names must be a list, not a dict."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="Type Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get("/ping", headers={"Authorization": "Bearer token123"})
+
+    assert response.status_code == 200
+    payload = json.loads(caplog.records[-1].message)
+    assert isinstance(payload["header_names"], list)
+
+
+def test_build_log_payload_does_not_log_header_values(monkeypatch, caplog):
+    """Sensitive header values must not appear anywhere in the log payload."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="No Value Leak Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+    secret_token = "super-secret-bearer-xyz"
+
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get(
+            "/ping",
+            headers={"Authorization": f"Bearer {secret_token}"},
+        )
+
+    assert response.status_code == 200
+    log_message = caplog.records[-1].message
+    assert secret_token not in log_message
+
+
+def test_build_log_payload_no_headers_key_in_payload(monkeypatch, caplog):
+    """Regression: old 'headers' key must be absent from the log payload."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="Regression Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get("/ping", headers={"X-API-Key": "my-secret-key"})
+
+    assert response.status_code == 200
+    payload = json.loads(caplog.records[-1].message)
+    assert "headers" not in payload
+    assert "header_names" in payload
+
+
+def test_build_log_payload_header_names_present_with_no_custom_headers(monkeypatch, caplog):
+    """header_names is a non-empty list even when no custom headers are sent."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="Minimal Headers Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get("/ping")
+
+    assert response.status_code == 200
+    payload = json.loads(caplog.records[-1].message)
+    assert "header_names" in payload
+    # TestClient always sends at least host header
+    assert isinstance(payload["header_names"], list)
+    assert len(payload["header_names"]) >= 1
+
+
+def test_build_log_payload_api_key_value_not_logged(monkeypatch, caplog):
+    """Regression: X-API-Key value must not appear in header_names entries."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="API Key Value Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+    api_key_value = "my-api-key-value"
+
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get("/ping", headers={"X-API-Key": api_key_value})
+
+    assert response.status_code == 200
+    payload = json.loads(caplog.records[-1].message)
+    # The value must not appear anywhere in the logged header names
+    assert api_key_value not in payload["header_names"]
+    # The header name itself (lowercased) should be present
+    assert "x-api-key" in payload["header_names"]

--- a/showcase-servers/content-automation-mcp/showcase_servers/common/test_security_common.py
+++ b/showcase-servers/content-automation-mcp/showcase_servers/common/test_security_common.py
@@ -242,8 +242,8 @@ def test_observability_redacts_sensitive_headers(monkeypatch, caplog):
 
     assert response.status_code == 200
     payload = json.loads(caplog.records[-1].message)
-    assert payload["headers"]["authorization"] != "Bearer super-secret-token"
-    assert payload["headers"]["x-api-key"] != "my-api-key-value"
+    assert "authorization" in payload["header_names"]
+    assert "x-api-key" in payload["header_names"]
 
 
 def test_sanitize_request_id_accepts_valid_format():

--- a/showcase-servers/content-automation-mcp/showcase_servers/common/test_security_common.py
+++ b/showcase-servers/content-automation-mcp/showcase_servers/common/test_security_common.py
@@ -372,11 +372,11 @@ def test_observability_logs_health_when_enabled(monkeypatch, caplog):
     assert payload["path"] == "/health"
 
 
-def test_build_log_payload_header_names_is_sorted(monkeypatch, caplog):
-    """header_names must be sorted alphabetically (new behavior)."""
+def test_log_payload_header_names_is_a_list(monkeypatch, caplog):
+    """header_names in the log payload must be a list, not a dict."""
     monkeypatch.setenv("LOG_LEVEL", "INFO")
 
-    app = FastAPI(title="Sort Test")
+    app = FastAPI(title="HeaderList Test")
     security.configure_observability(app)
 
     @app.get("/ping")
@@ -384,14 +384,33 @@ def test_build_log_payload_header_names_is_sorted(monkeypatch, caplog):
         return {"ok": True}
 
     client = TestClient(app)
+    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
+        response = client.get("/ping", headers={"X-Custom-Header": "some-value"})
 
+    assert response.status_code == 200
+    payload = json.loads(caplog.records[-1].message)
+    assert isinstance(payload["header_names"], list)
+
+
+def test_log_payload_header_names_sorted_alphabetically(monkeypatch, caplog):
+    """header_names must be sorted alphabetically."""
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+    app = FastAPI(title="Sorted Headers Test")
+    security.configure_observability(app)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
     with caplog.at_level("INFO", logger=security.LOGGER_NAME):
         response = client.get(
             "/ping",
             headers={
-                "Z-Custom": "z-value",
-                "A-Custom": "a-value",
-                "M-Custom": "m-value",
+                "Z-Last-Header": "z-value",
+                "A-First-Header": "a-value",
+                "M-Middle-Header": "m-value",
             },
         )
 
@@ -401,11 +420,11 @@ def test_build_log_payload_header_names_is_sorted(monkeypatch, caplog):
     assert header_names == sorted(header_names)
 
 
-def test_build_log_payload_header_names_is_list(monkeypatch, caplog):
-    """header_names must be a list, not a dict."""
+def test_log_payload_no_header_values_in_payload(monkeypatch, caplog):
+    """Header values must not appear anywhere in the log payload."""
     monkeypatch.setenv("LOG_LEVEL", "INFO")
 
-    app = FastAPI(title="Type Test")
+    app = FastAPI(title="No Values Test")
     security.configure_observability(app)
 
     @app.get("/ping")
@@ -413,45 +432,29 @@ def test_build_log_payload_header_names_is_list(monkeypatch, caplog):
         return {"ok": True}
 
     client = TestClient(app)
-
-    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
-        response = client.get("/ping", headers={"Authorization": "Bearer token123"})
-
-    assert response.status_code == 200
-    payload = json.loads(caplog.records[-1].message)
-    assert isinstance(payload["header_names"], list)
-
-
-def test_build_log_payload_does_not_log_header_values(monkeypatch, caplog):
-    """Sensitive header values must not appear anywhere in the log payload."""
-    monkeypatch.setenv("LOG_LEVEL", "INFO")
-
-    app = FastAPI(title="No Value Leak Test")
-    security.configure_observability(app)
-
-    @app.get("/ping")
-    def ping():
-        return {"ok": True}
-
-    client = TestClient(app)
-    secret_token = "super-secret-bearer-xyz"
+    secret_value = "Bearer super-secret-token-12345"
+    api_key_value = "my-very-secret-api-key"
 
     with caplog.at_level("INFO", logger=security.LOGGER_NAME):
         response = client.get(
             "/ping",
-            headers={"Authorization": f"Bearer {secret_token}"},
+            headers={
+                "Authorization": secret_value,
+                "X-API-Key": api_key_value,
+            },
         )
 
     assert response.status_code == 200
-    log_message = caplog.records[-1].message
-    assert secret_token not in log_message
+    raw_log = caplog.records[-1].message
+    assert secret_value not in raw_log
+    assert api_key_value not in raw_log
 
 
-def test_build_log_payload_no_headers_key_in_payload(monkeypatch, caplog):
-    """Regression: old 'headers' key must be absent from the log payload."""
+def test_log_payload_no_headers_key(monkeypatch, caplog):
+    """The old 'headers' key must not be present in the log payload."""
     monkeypatch.setenv("LOG_LEVEL", "INFO")
 
-    app = FastAPI(title="Regression Test")
+    app = FastAPI(title="No Headers Key Test")
     security.configure_observability(app)
 
     @app.get("/ping")
@@ -459,9 +462,8 @@ def test_build_log_payload_no_headers_key_in_payload(monkeypatch, caplog):
         return {"ok": True}
 
     client = TestClient(app)
-
     with caplog.at_level("INFO", logger=security.LOGGER_NAME):
-        response = client.get("/ping", headers={"X-API-Key": "my-secret-key"})
+        response = client.get("/ping", headers={"Authorization": "Bearer token"})
 
     assert response.status_code == 200
     payload = json.loads(caplog.records[-1].message)
@@ -469,11 +471,11 @@ def test_build_log_payload_no_headers_key_in_payload(monkeypatch, caplog):
     assert "header_names" in payload
 
 
-def test_build_log_payload_header_names_present_with_no_custom_headers(monkeypatch, caplog):
-    """header_names is a non-empty list even when no custom headers are sent."""
+def test_log_payload_header_names_contains_sent_names(monkeypatch, caplog):
+    """Non-sensitive header names must appear in header_names."""
     monkeypatch.setenv("LOG_LEVEL", "INFO")
 
-    app = FastAPI(title="Minimal Headers Test")
+    app = FastAPI(title="Header Names Present")
     security.configure_observability(app)
 
     @app.get("/ping")
@@ -481,38 +483,77 @@ def test_build_log_payload_header_names_present_with_no_custom_headers(monkeypat
         return {"ok": True}
 
     client = TestClient(app)
-
     with caplog.at_level("INFO", logger=security.LOGGER_NAME):
-        response = client.get("/ping")
+        response = client.get(
+            "/ping",
+            headers={
+                "X-Custom-Header": "value1",
+                "Accept-Language": "en-US",
+            },
+        )
 
     assert response.status_code == 200
     payload = json.loads(caplog.records[-1].message)
-    assert "header_names" in payload
-    # TestClient always sends at least host header
-    assert isinstance(payload["header_names"], list)
-    assert len(payload["header_names"]) >= 1
+    assert "x-custom-header" in payload["header_names"]
+    assert "accept-language" in payload["header_names"]
 
 
-def test_build_log_payload_api_key_value_not_logged(monkeypatch, caplog):
-    """Regression: X-API-Key value must not appear in header_names entries."""
-    monkeypatch.setenv("LOG_LEVEL", "INFO")
+def test_build_log_payload_header_names_directly():
+    """Unit test for _build_log_payload: header_names is sorted keys of request headers."""
+    headers = {"z-header": "z-val", "a-header": "a-val", "m-header": "m-val"}
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="10.0.0.1"),
+        headers=headers,
+        method="GET",
+        url=SimpleNamespace(path="/test"),
+    )
+    payload = security._build_log_payload(
+        request=request,
+        request_id="test-id",
+        status_code=200,
+        duration_ms=12.5,
+        service_name="test-service",
+    )
+    assert payload["header_names"] == ["a-header", "m-header", "z-header"]
+    assert "headers" not in payload
 
-    app = FastAPI(title="API Key Value Test")
-    security.configure_observability(app)
 
-    @app.get("/ping")
-    def ping():
-        return {"ok": True}
-
-    client = TestClient(app)
-    api_key_value = "my-api-key-value"
-
-    with caplog.at_level("INFO", logger=security.LOGGER_NAME):
-        response = client.get("/ping", headers={"X-API-Key": api_key_value})
-
-    assert response.status_code == 200
-    payload = json.loads(caplog.records[-1].message)
-    # The value must not appear anywhere in the logged header names
-    assert api_key_value not in payload["header_names"]
-    # The header name itself (lowercased) should be present
+def test_build_log_payload_header_values_absent():
+    """Unit test: header values must not appear in _build_log_payload output."""
+    headers = {"authorization": "Bearer secret-token", "x-api-key": "sensitive-key"}
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="10.0.0.1"),
+        headers=headers,
+        method="POST",
+        url=SimpleNamespace(path="/data"),
+    )
+    payload = security._build_log_payload(
+        request=request,
+        request_id="req-abc",
+        status_code=201,
+        duration_ms=5.0,
+        service_name="svc",
+    )
+    serialized = json.dumps(payload)
+    assert "Bearer secret-token" not in serialized
+    assert "sensitive-key" not in serialized
+    assert "authorization" in payload["header_names"]
     assert "x-api-key" in payload["header_names"]
+
+
+def test_build_log_payload_empty_headers():
+    """Unit test: _build_log_payload with no request headers yields empty list."""
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="127.0.0.1"),
+        headers={},
+        method="GET",
+        url=SimpleNamespace(path="/empty"),
+    )
+    payload = security._build_log_payload(
+        request=request,
+        request_id="req-empty",
+        status_code=200,
+        duration_ms=1.0,
+        service_name="svc",
+    )
+    assert payload["header_names"] == []


### PR DESCRIPTION
Potential fix for [https://github.com/JRM-FusionAL/mcp-consulting-kit/security/code-scanning/11](https://github.com/JRM-FusionAL/mcp-consulting-kit/security/code-scanning/11)

To fix this without changing core behavior, remove sensitive header values from logs by replacing the logged `headers` object with low-risk metadata (for example, header names only). This preserves observability while preventing any possibility of secret values being written.

Best single change in `showcase-servers/api-integration-hub/showcase_servers/common/security.py`:
- In `_build_log_payload(...)`, stop placing `redacted_headers` (values included) into `payload`.
- Instead, include only header keys (e.g., `header_names`) so request diagnostics remain useful.
- Keep existing redaction helpers untouched (they may still be used elsewhere), but ensure this sink no longer receives secret-bearing values.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**What** — Prevent clear-text sensitive header values from being written to request observability logs while keeping header observability.

**Changes**
- `showcase-servers/api-integration-hub/showcase_servers/common/security.py`
  - Updated `_build_log_payload(...)` to stop emitting redacted header values and instead log only an alphabetically sorted `header_names` list derived from `request.headers` keys.
- `showcase-servers/api-integration-hub/showcase_servers/common/test_security_common.py`
  - Updated observability assertions to verify sensitive header *names* (e.g., `authorization`, `x-api-key`) appear in `payload["header_names"]`.
  - Added checks that the legacy `headers` key is absent, `header_names` is a sorted list, and no header *values* appear anywhere in the logged payload/serialized message.
- `showcase-servers/content-automation-mcp/showcase_servers/common/test_security_common.py`
  - Mirrored the same observability/log-payload assertion and schema/redaction guarantee updates.

**Dependencies**
- No new packages, env vars, or config added.

**Testing**
- Run the unit test suite and verify `test_observability_redacts_sensitive_headers` (and the new log-payload schema/redaction tests) confirm:
  - `payload["header_names"]` includes `authorization` and `x-api-key`
  - sensitive header values are not present in the logged payload / serialized message
  - the old `headers` key is no longer emitted
  - `header_names` is alphabetically sorted and correctly handles empty headers

**Contributors**

| Author | Lines added | Lines removed |
| --- | ---: | ---: |
| coderabbitai[bot] | 1948 | 124 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->