### PR TITLE
chore(deps): bump vite and @vitejs/plugin-react in frontend/

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,8 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^6.0.2",
-    "vite": "^8.0.16"
+    "@vitejs/plugin-react": "^6.0.3",
+    "vite": "^8.1.5"
   },
   "overrides": {
     "@babel/core": ">=7.29.6"


### PR DESCRIPTION
## Summary

From a scheduled dependency audit across all connected repos. This repo's existing dependency-update automation only tracks the Python `showcase-servers/*` packages (see the many open "chore: update Python dependencies in showcase-servers/*" PRs) — it doesn't touch `frontend/package.json`, so these two were a genuine gap:

- `vite`: `^8.0.16` → `^8.1.5` (minor, no breaking changes in the changelog)
- `@vitejs/plugin-react`: `^6.0.2` → `^6.0.3` (patch)

Left `react`/`react-dom` on `18.3.1` — that's the terminal patch of the 18.x line, and the jump to 19.x (to match `FusionAL-Command-Center`, which already runs React 19) is a deliberate migration decision, not a mechanical version bump, so I didn't force it here.

## Test plan

- [ ] `npm install && npm run build` succeeds in `frontend/`
- [ ] Dev server (`npm run dev`) still serves the app correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfqGXcGGJGrwxErnzooyAN)_