### PR TITLE
fix(docker): bump nginx off possibly-CVE-affected line, pin floating tags

### DIFF
--- a/docker-compose.cloudflare.yaml
+++ b/docker-compose.cloudflare.yaml
@@ -1,6 +1,6 @@
 services:
   cloudflared:
-    image: cloudflare/cloudflared:latest
+    image: cloudflare/cloudflared:2026.7.3
     container_name: mcp-cloudflared
     restart: unless-stopped
     command: tunnel --no-autoupdate run

--- a/docker-compose.proxy.yaml
+++ b/docker-compose.proxy.yaml
@@ -1,6 +1,6 @@
 services:
   mcp-proxy:
-    image: nginx:1.27-alpine
+    image: nginx:1.30-alpine
     container_name: mcp-proxy
     ports:
       - "127.0.0.1:8088:8080"

--- a/nginx-compose.yaml
+++ b/nginx-compose.yaml
@@ -1,6 +1,6 @@
 services:
   nginx:
-    image: nginx:alpine
+    image: nginx:1.30-alpine
     container_name: fusional-nginx
     ports:
       - "8088:80"


### PR DESCRIPTION
## Summary

Fixes found by a scheduled dependency audit (2026-08-12) covering all JRM-FusionAL repos. This repo had the most audit surface (7+ manifests); this PR closes the two Docker-base-image findings:

- **`docker-compose.proxy.yaml` pinned `nginx:1.27-alpine`**, which may fall inside the affected range for CVE-2026-28755 (documented through 1.29.6 — the exact lower bound wasn't fully confirmable from available advisory text, so treat this as "possibly affected, now moot" rather than a confirmed hit). Bumped to `nginx:1.30-alpine`.
- **`nginx-compose.yaml` used a bare, unpinned `nginx:alpine` tag** — same target version bump applied, closing a build-reproducibility gap independent of the CVE question.
- **`docker-compose.cloudflare.yaml` used a floating `cloudflare/cloudflared:latest` tag** — pinned to `2026.7.3` (current latest release as of audit date).

## Explicitly NOT done here (flagged for follow-up, not same-day fixes)
- `redis` client pinned `7.4.0` across 4 showcase services vs. current `8.0.x` — major bump, changes RESP3-default wire protocol, needs its own testing pass.
- `openai` is an unpinned floating range (`>=1.30.0`) in `business-intelligence-mcp` vs. exact-pinned `2.45.0` in `social-poster-mcp` — inconsistent pinning discipline, worth a repo-wide policy decision.
- `frontend/package.json` and `app/package.json` are drifted duplicates (different React majors, different Vite-plugin majors) — should be consolidated, not just version-bumped.
- `showcase-servers/github-mcp-safe/` has diverged into a different tech stack from the standalone `github-mcp-safe` repo — a docs/architecture question, not a dependency fix.
- Python base-image inconsistency (`python:3.11-slim` everywhere except `Dockerfile.intelligence` on `python:3.12-slim`) — worth standardizing but is a broader rebuild/test exercise.

## Test plan
- [ ] `docker compose -f docker-compose.proxy.yaml config` validates
- [ ] `docker compose -f nginx-compose.yaml config` validates
- [ ] `docker compose -f docker-compose.cloudflare.yaml config` validates
- [ ] Pull and smoke-test the new nginx/cloudflared images against `deploy/nginx/mcp.conf` and `nginx.conf`

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqGPcV7UK5omxGSWxATgLD)_